### PR TITLE
Fix stream_params() to correctly detect location

### DIFF
--- a/R/stream.R
+++ b/R/stream.R
@@ -200,7 +200,7 @@ parse_stream <- function(file_name) {
 stream_params <- function(stream) {
 
   if (!all(suppressWarnings(is.na(as.numeric(stream))))) {
-    if (all(is.integer(as.integer(stream)))) {
+    if (all(is.integer(as.numeric(stream)))) {
       params <- list(follow = stream)
     } else {
       params <- list(locations = stream)


### PR DESCRIPTION

stream_tweets() does not seem to correctly detect locations in the q argument.

It seems the first else statement in stream_params() is not capable of reaching {params <- list(locations = stream)} because the corresponding if statement checks is.integer() on the result of as.numeric() and therefore is (almost) always true.

If not mistaken, changing as.integer() to as.numeric() should fix it.