### PR TITLE
Explain in documentation when this parameter is silently ignored

### DIFF
--- a/R/post.R
+++ b/R/post.R
@@ -10,7 +10,7 @@
 #'   fetches a non-exhausted token from an environment
 #'   variable tokens.
 #' @param in_reply_to_status_id Status ID of tweet to which you'd like
-#'   to reply.
+#'   to reply. Note: in line with the Twitter API, this parameter is ignored unless the author of the tweet this parameter references is mentioned within the status text.
 #' @examples
 #' \dontrun{
 #' x <- rnorm(300)

--- a/man/post_tweet.Rd
+++ b/man/post_tweet.Rd
@@ -20,7 +20,7 @@ fetches a non-exhausted token from an environment
 variable tokens.}
 
 \item{in_reply_to_status_id}{Status ID of tweet to which you'd like
-to reply.}
+to reply. Note: in line with the Twitter API, this parameter is ignored unless the author of the tweet this parameter references is mentioned within the status text.}
 }
 \description{
 Posts status update to user's Twitter account


### PR DESCRIPTION
One can waste a lot of time troubleshooting what is going wrong. Giving this information in the documentation prevents that.