### PR TITLE
make n= work in get_timeline()

### DIFF
--- a/R/timeline.R
+++ b/R/timeline.R
@@ -84,7 +84,7 @@ get_timeline_ <- function(user, n = 200,
 
   params <- list(
     user_type = user,
-    count = 200,
+    count = n,
     max_id = max_id,
     tweet_mode = "extended",
     ...)


### PR DESCRIPTION
The get_timeline() function pulls 200 tweets regardless of what the n= argument is set to.  I replaced the 200 in a later call with n to make the n= argument work.