### PR TITLE
Fix for `get_timeline` ignoring `home` parameter

### DIFF
--- a/R/timeline.R
+++ b/R/timeline.R
@@ -67,6 +67,7 @@ get_timeline <- function(user,
     user = user,
     n = n,
     max_id = max_id,
+    home = home,
     parse = parse,
     check = check,
     token = token

--- a/R/timeline.R
+++ b/R/timeline.R
@@ -12,7 +12,7 @@
 #'   or home-timeline. By default, home is set to FALSE, which means
 #'   \code{get_timeline} returns tweets posted by the given user. To
 #'   return a user's home timeline feed, that is, the tweets posted by
-#'   accounts followed by a user, set the home to false.
+#'   accounts followed by a user, set the home to TRUE.
 #' @param parse Logical, indicating whether to return parsed
 #'   (data.frames) or nested list object. By default, \code{parse =
 #'   TRUE} saves users from the time [and frustrations] associated

--- a/tests/testthat/test_get_timelines.R
+++ b/tests/testthat/test_get_timelines.R
@@ -21,3 +21,15 @@ test_that("get_timeline", {
   expect_gt(ncol(users_data(x)), 15)
   expect_named(users_data(x))
 })
+
+test_that("get_timeline(... home = TRUE ...) passes home to get_timeline_", {
+  with_mock(
+    `rtweet::get_timeline_` = function(user, n = 1, ...) {
+      dots <- list(...)
+      expect_true(dots$home)
+      return(NULL)
+    },
+
+    x <- get_timeline("ignored", home = TRUE)
+  )
+})


### PR DESCRIPTION
This fixes a bug where `get_timeline` was ignoring the `home` parameter.

I also added a regression test for this and fixed a typo in the `get_timeline` documentation.