### PR TITLE
verify no spaces in usernames for get_favorites

### DIFF
--- a/R/favorites.R
+++ b/R/favorites.R
@@ -71,7 +71,7 @@ get_favorites_call <- function(user,
     token <- check_token(token)
   }
   ## check inputs
-  stopifnot(is.atomic(user), is.numeric(n))
+  stopifnot(is.atomic(user), is.numeric(n), sapply(user, is.valid.username))
   if (length(user) == 0L) {
     stop("No user found", call. = FALSE)
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -563,3 +563,7 @@ obs2string <- function(x, sep) {
   x[is.na(x)] <- ""
   paste(x, collapse = sep)
 }
+
+is.valid.username <- function(username) {
+  !grepl(' ', username);
+}

--- a/tests/testthat/test_get_favorites.R
+++ b/tests/testthat/test_get_favorites.R
@@ -17,3 +17,9 @@ test_that("get_favorites returns tweets data", {
   expect_gt(ncol(users_data(x)), 15)
   expect_named(users_data(x))
 })
+
+test_that("get_favorites throws an error if usernames have spaces in them", {
+  n <- 2
+  token <- readRDS("twitter_tokens")
+  expect_error(get_favorites(c("elonmusk","elon musk"), n=n))
+})


### PR DESCRIPTION
I was (admittedly, stupidly) calling get_favorites with a username that included a space in it. The get_favorites function returned rows that were favorited by my authenticating username, but then related them to the usernames with spaces in them. 

This was confusing to me. I added a simple check on the usernames to see if they have spaces, with a test. I also checked all tests and they passed. 

I totally understand this may be too basic/simple. Anyway, thanks for this package @mkearney!