### PR TITLE
Fix source

### DIFF
--- a/R/tweets_and_users.R
+++ b/R/tweets_and_users.R
@@ -136,6 +136,7 @@ status_object_ <- function(x) {
 tweets_to_tbl_ <- function(dat) {
   if (NROW(dat) == 0L) return(data.frame())
   dat$display_text_width <- display_text_range(dat)
+  dat$text <- ifelse(dat$truncated, dat$extended_tweet$full_text, dat$text)
   ## extended entitites > media
   if (has_name(dat, "extended_entities") &&
       has_name(dat[['extended_entities']], "media")) {

--- a/R/tweets_and_users.R
+++ b/R/tweets_and_users.R
@@ -496,9 +496,9 @@ wrangle_retweet_status <- function(x) {
     x$retweet_text <- NA_character_
   }
   if (has_name(rst, "source")) {
-    x$retweet_screen_name <- rst$source
+    x$retweet_source <- rst$source
   } else {
-    x$retweet_screen_name <- NA_character_
+    x$retweet_source <- NA_character_
   }
   if (has_name(rst, "created_at")) {
     x$retweet_created_at <- format_date(rst$created_at)
@@ -582,9 +582,9 @@ wrangle_quote_status <- function(x) {
     x$quoted_text <- NA_character_
   }
   if (has_name(qst, "source")) {
-    x$quoted_screen_name <- qst$source
+    x$quoted_source <- qst$source
   } else {
-    x$quoted_screen_name <- NA_character_
+    x$quoted_source <- NA_character_
   }
   if (has_name(qst, "created_at")) {
     x$quoted_created_at <- format_date(qst$created_at)

--- a/R/tweets_and_users.R
+++ b/R/tweets_and_users.R
@@ -136,7 +136,6 @@ status_object_ <- function(x) {
 tweets_to_tbl_ <- function(dat) {
   if (NROW(dat) == 0L) return(data.frame())
   dat$display_text_width <- display_text_range(dat)
-  dat$text <- ifelse(dat$truncated, dat$extended_tweet$full_text, dat$text)
   ## extended entitites > media
   if (has_name(dat, "extended_entities") &&
       has_name(dat[['extended_entities']], "media")) {

--- a/R/tweets_and_users.R
+++ b/R/tweets_and_users.R
@@ -496,7 +496,7 @@ wrangle_retweet_status <- function(x) {
     x$retweet_text <- NA_character_
   }
   if (has_name(rst, "source")) {
-    x$retweet_source <- rst$source
+    x$retweet_source <- clean_source_(rst$source)
   } else {
     x$retweet_source <- NA_character_
   }
@@ -582,7 +582,7 @@ wrangle_quote_status <- function(x) {
     x$quoted_text <- NA_character_
   }
   if (has_name(qst, "source")) {
-    x$quoted_source <- qst$source
+    x$quoted_source <- clean_source_(qst$source)
   } else {
     x$quoted_source <- NA_character_
   }


### PR DESCRIPTION
This pull fixes the retweet_source and quoted_source columns so they use the parsed data, and uses your internal clean_source_ function to strip out the ungodly href garbage from the beginning of the source tags