### PR TITLE
Standardize documentation of `max_id` parameters

### DIFF
--- a/R/direct_messages.R
+++ b/R/direct_messages.R
@@ -69,8 +69,8 @@ direct_messages <- function(n = 50,
 #'   the number of Tweets which can be accessed through the API. If
 #'   the limit of Tweets has occurred since the since_id, the since_id
 #'   will be forced to the oldest ID available.
-#' @param max_id optional Returns results with an ID less than (that
-#'   is, older than) or equal to the specified ID.
+#' @param max_id Character, returns results with an ID less than (that is,
+#'   older than) or equal to `max_id`.
 #' @param n optional Specifies the number of direct messages to try
 #'   and retrieve, up to a maximum of 200. The value of count is best
 #'   thought of as a limit to the number of Tweets to return because

--- a/R/favorites.R
+++ b/R/favorites.R
@@ -14,8 +14,8 @@
 #'   limits to the number of tweets returned by the REST API. If the
 #'   limit is hit, since_id is adjusted (by Twitter) to the oldest ID
 #'   available.
-#' @param max_id Returns results with status_id less (older) than or
-#'   equal to (if hit limit) the specified status_id.
+#' @param max_id Character, returns results with an ID less than (that is,
+#'   older than) or equal to `max_id`.
 #' @param parse Logical, indicating whether to return parsed vector or
 #'   nested list object. By default, \code{parse = TRUE}
 #'   saves you the time [and frustrations] associated with

--- a/R/get-my-timeline.R
+++ b/R/get-my-timeline.R
@@ -9,8 +9,8 @@
 #' @md
 #' @param n Number of tweets to return per timeline. Defaults to 100.
 #'   Must be of length 1 or equal to length of user.
-#' @param max_id Character, status_id from which returned tweets
-#'   should be older than.
+#' @param max_id Character, returns results with an ID less than (that is,
+#'   older than) or equal to `max_id`.
 #' @param parse Logical, indicating whether to return parsed
 #'   (data.frames) or nested list object. By default, \code{parse =
 #'   TRUE} saves users from the time (and frustrations) associated

--- a/R/mentions.R
+++ b/R/mentions.R
@@ -13,8 +13,8 @@
 #'   number of Tweets which can be accessed through the API. If the
 #'   limit of Tweets has occurred since the since_id, the since_id
 #'   will be forced to the oldest ID available.
-#' @param max_id Returns results with an ID less than (that is, older
-#'   than) or equal to the specified ID.
+#' @param max_id Character, returns results with an ID less than (that is,
+#'   older than) or equal to `max_id`.
 #' @param parse Logical indicating whether to convert the response
 #'   object into an R list. Defaults to TRUE.
 #' @param token Every user should have their own Oauth (Twitter API) token. By

--- a/R/search_tweets.R
+++ b/R/search_tweets.R
@@ -39,9 +39,9 @@
 #'   are distinct from quotes (retweets with additional text provided
 #'   from sender) or manual retweets (old school method of manually
 #'   entering "RT" into the text of one's tweets).
-#' @param max_id Character string specifying the [oldest] status id
-#'   beyond which search results should resume returning.  Especially
-#'   useful large data returns that require multiple iterations
+#' @param max_id Character, returns results with an ID less
+#'   than (that is, older than) or equal to `max_id`.  Especially
+#'   useful for large data returns that require multiple iterations
 #'   interrupted by user time constraints. For searches exceeding
 #'   18,000 tweets, users are encouraged to take advantage of rtweet's
 #'   internal automation procedures for waiting on rate limits by

--- a/R/timeline.R
+++ b/R/timeline.R
@@ -6,8 +6,8 @@
 #' @param user Vector of user names, user IDs, or a mixture of both.
 #' @param n Number of tweets to return per timeline. Defaults to 100.
 #'   Must be of length 1 or equal to length of user.
-#' @param max_id Character, status_id from which returned tweets
-#'   should be older than.
+#' @param max_id Character, returns results with an ID less than (that is,
+#'   older than) or equal to `max_id`.
 #' @param home Logical, indicating whether to return a user-timeline
 #'   or home-timeline. By default, home is set to FALSE, which means
 #'   \code{get_timeline} returns tweets posted by the given user. To


### PR DESCRIPTION
After reading #253 I realized I had completely mis-interpreted the meaning of the `max_id` in `search_tweets()` in the exact opposite of its actual intended meaning.

This PR standardizes the language among `max_id` parameters, following the Twitter API documentation and the language used in other rwteet functions.

I only changed the source and didn't re-roxygenize.
