### PR TITLE
Fix typo in code example

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -92,7 +92,7 @@ and create a new app by completing the form fields (note: **users must enter the
       app = "my_twitter_research_app",
       consumer_key = "XYznzPFOFZR2a39FwWKN1Jp41",
       consumer_secret = "CtkGEWmSevZqJuKl6HHrBxbCybxI1xGLqrD5ynPd9jG0SoHZbD",
-      acess_token = "9551451262-wK2EmA942kxZYIwa5LMKZoQA4Xc2uyIiEwu2YXL",
+      access_token = "9551451262-wK2EmA942kxZYIwa5LMKZoQA4Xc2uyIiEwu2YXL",
       access_secret = "9vpiSGKg1fIPQtxc5d5ESiFlZQpfbknEN1f1m2xe5byw7")
     ```
 


### PR DESCRIPTION
Fixing "acess" to "access" in "Authenticate via access token"