### PR TITLE
Docs now mention temporal order of follows

### DIFF
--- a/R/followers.R
+++ b/R/followers.R
@@ -51,6 +51,11 @@
 #'   reset. Users should monitor and test this before making
 #'   especially large calls as any systematic issues could create
 #'   sizable inefficiencies.
+#'
+#'   At this time, results are ordered with the most recent following first —
+#'   however, this ordering is subject to unannounced change and eventual
+#'   consistency issues. While this remains true it is possible iteratively build
+#'   follower lists for a user over time.
 #' @seealso
 #'   \url{https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-followers-ids}
 #' @examples

--- a/R/friends.R
+++ b/R/friends.R
@@ -229,8 +229,8 @@ get_friend <- function(url, token = NULL) {
     if (has_name_(url, "query") &&
         any(grepl("user_id|screen_name", names(url$query)))) {
       warning("^^ warning regarding user: ",
-              url$query[[grep("screen_name|user_id", names(url$query))]],
-              call. = FALSE, immediate. = TRUE)
+        url$query[[grep("screen_name|user_id", names(url$query))]],
+        call. = FALSE, immediate. = TRUE)
     }
     return(list(ids = character()))
   }

--- a/R/friends.R
+++ b/R/friends.R
@@ -67,6 +67,11 @@
 #'   for a second time) until the next rate limit reset. Users should monitor
 #'   and test this before making especially large calls as any systematic issues
 #'   could create sizable inefficiencies.
+#'
+#'   At this time, results are ordered with the most recent following first —
+#'   however, this ordering is subject to unannounced change and eventual
+#'   consistency issues. While this remains true it is possible iteratively build
+#'   friends lists for a user over time.
 #' @return A tibble data frame with two columns, "user" for name or ID of target
 #'   user and "user_id" for follower IDs.
 #' @family ids
@@ -199,19 +204,19 @@ get_friends_ <- function(users,
     )
     ## if !retryonratelimit then if necessary exhaust what can with token
     f <- get_friend(url, token = token)
-      if (has_name_(f, "errors")) {
-        warning(f$errors[["message"]], call. = FALSE)
-        return(list(data.frame()))
-      } else if (parse) {
-        nextcursor <- f[["next_cursor"]]
-        if (length(f[["ids"]]) == 0) {
-          f <- tibble::as_tibble()
-        } else {
-          f <- tibble::as_tibble(
-            list(user = users, user_id = f[["ids"]]))
-          attr(f, "next_cursor") <- nextcursor
-        }
+    if (has_name_(f, "errors")) {
+      warning(f$errors[["message"]], call. = FALSE)
+      return(list(data.frame()))
+    } else if (parse) {
+      nextcursor <- f[["next_cursor"]]
+      if (length(f[["ids"]]) == 0) {
+        f <- tibble::as_tibble()
+      } else {
+        f <- tibble::as_tibble(
+          list(user = users, user_id = f[["ids"]]))
+        attr(f, "next_cursor") <- nextcursor
       }
+    }
   }
   f
 }
@@ -224,8 +229,8 @@ get_friend <- function(url, token = NULL) {
     if (has_name_(url, "query") &&
         any(grepl("user_id|screen_name", names(url$query)))) {
       warning("^^ warning regarding user: ",
-        url$query[[grep("screen_name|user_id", names(url$query))]],
-        call. = FALSE, immediate. = TRUE)
+              url$query[[grep("screen_name|user_id", names(url$query))]],
+              call. = FALSE, immediate. = TRUE)
     }
     return(list(ids = character()))
   }
@@ -280,9 +285,9 @@ my_friendships <- function(user,
 
 
 lookup_friendships_ <- function(source,
-                              target,
-                              parse = TRUE,
-                              token = NULL) {
+                                target,
+                                parse = TRUE,
+                                token = NULL) {
   stopifnot(is.atomic(source), is.atomic(target))
   token <- check_token(token)
   query <- "friendships/show"

--- a/man/get_followers.Rd
+++ b/man/get_followers.Rd
@@ -71,6 +71,11 @@ When \code{retryonratelimit = TRUE} this function
   reset. Users should monitor and test this before making
   especially large calls as any systematic issues could create
   sizable inefficiencies.
+
+  At this time, results are ordered with the most recent following first —
+  however, this ordering is subject to unannounced change and eventual
+  consistency issues. While this remains true it is possible iteratively build
+  follower lists for a user over time.
 }
 \examples{
 

--- a/man/get_friends.Rd
+++ b/man/get_friends.Rd
@@ -75,6 +75,11 @@ When \code{retryonratelimit = TRUE} this function internally
   for a second time) until the next rate limit reset. Users should monitor
   and test this before making especially large calls as any systematic issues
   could create sizable inefficiencies.
+
+  At this time, results are ordered with the most recent following first —
+  however, this ordering is subject to unannounced change and eventual
+  consistency issues. While this remains true it is possible iteratively build
+  friends lists for a user over time.
 }
 \examples{
 


### PR DESCRIPTION
The Twitter API docs make clear that at present follows/friends are ordered temporally. This PR updates the documentation for `get_friends()` and `get_folllowers()` with this information.
Note that this PR came from conversation with the package author https://twitter.com/martinjhnhadley/status/1090302261824233473