### PR TITLE
correctly spell argument in create_token

### DIFF
--- a/vignettes/auth.Rmd
+++ b/vignettes/auth.Rmd
@@ -110,7 +110,7 @@ token <- create_token(
   app = "my_twitter_research_app",
   consumer_key = "XYznzPFOFZR2a39FwWKN1Jp41",
   consumer_secret = "CtkGEWmSevZqJuKl6HHrBxbCybxI1xGLqrD5ynPd9jG0SoHZbD",
-  acess_token = "9551451262-wK2EmA942kxZYIwa5LMKZoQA4Xc2uyIiEwu2YXL",
+  access_token = "9551451262-wK2EmA942kxZYIwa5LMKZoQA4Xc2uyIiEwu2YXL",
   access_secret = "9vpiSGKg1fIPQtxc5d5ESiFlZQpfbknEN1f1m2xe5byw7")
 ```
 


### PR DESCRIPTION
error noted in issue: https://github.com/mkearney/rtweet/issues/283

corrects typo

does _not_ typo in reference to .png image